### PR TITLE
Fix embedded python coloring when using <% %> construct.

### DIFF
--- a/grammars/html (mako).cson
+++ b/grammars/html (mako).cson
@@ -7,7 +7,7 @@
 'name': 'HTML (Mako)'
 'patterns': [
   {
-    'begin': '(<%) '
+    'begin': '(<%)'
     'captures':
       '1':
         'name': 'keyword.control'


### PR DESCRIPTION
I don't seem to have a problem with the python coloring within <% %> in sublime text, but in atom, I do.  

The regexp for <% is expecting a space after, however, if the editor is stripping trailing spaces, the regex ends up not matching properly, and the python code within doesn't get colored.

Removing the space from the regex seems to fix it.
