### PR TITLE
Rearrange the order of the patterns to match <% last

### DIFF
--- a/grammars/html (mako).cson
+++ b/grammars/html (mako).cson
@@ -7,19 +7,6 @@
 'name': 'HTML (Mako)'
 'patterns': [
   {
-    'begin': '(<%)'
-    'captures':
-      '1':
-        'name': 'keyword.control'
-    'end': '(%>)'
-    'name': 'source.mako.substitution'
-    'patterns': [
-      {
-        'include': 'source.python'
-      }
-    ]
-  }
-  {
     'begin': '(<%(text)>)'
     'captures':
       '1':
@@ -284,6 +271,19 @@
       }
       {
         'include': '#tag-stuff'
+      }
+    ]
+  }
+  {
+    'begin': '(<%)'
+    'captures':
+      '1':
+        'name': 'keyword.control'
+    'end': '(%>)'
+    'name': 'source.mako.substitution'
+    'patterns': [
+      {
+        'include': 'source.python'
       }
     ]
   }


### PR DESCRIPTION
Since its least specific, the <% need to be matched last or else it blows up things like <%def, etc.

This should be better than the last commit.
