### PR TITLE
Add comments syntax highlighting

### DIFF
--- a/grammars/html (mako).cson
+++ b/grammars/html (mako).cson
@@ -288,6 +288,16 @@
     ]
   }
   {
+    'begin': '^.*<%doc>'
+    'end': '</%doc>'
+    'name': 'comment.block.mako'
+  }
+  {
+    'begin': '^([ \\t]+)?(?=##)'
+    'end': '\\n'
+    'name': 'comment.line.mako'
+  }
+  {
     'include': 'text.html.basic'
   }
 ]

--- a/settings/language-mako.cson
+++ b/settings/language-mako.cson
@@ -1,0 +1,3 @@
+'.source.mako':
+  'editor':
+    'commentStart': '## '


### PR DESCRIPTION
Also fix default comments (inline `## ` instead of `/* */`).

Fix #3