### PR TITLE
Match line comments at start of line

### DIFF
--- a/grammars/html (mako).cson
+++ b/grammars/html (mako).cson
@@ -59,7 +59,7 @@
     ]
   }
   {
-    'begin': '^(#)'
+    'begin': '^(#)(?!#)'
     'beginCaptures':
       '1':
         'name': 'keyword.control'


### PR DESCRIPTION
These were being overriden by a closer match to the keyword control regular expression. Added a negative lookahead to keyword control regular expression that prevents it from matching if two hashes start the line.

Closes https://github.com/stevepaulo/language-mako/issues/7
